### PR TITLE
Changed the login method to use a JSON object (FR)

### DIFF
--- a/lib/piccoma-fr.js
+++ b/lib/piccoma-fr.js
@@ -5,10 +5,11 @@ import Piccoma from './piccoma.js'
 export default class PiccomaFr extends Piccoma {
   async login(email, password) {
     console.log('login...')
-    const params = new URLSearchParams()
-    params.set('redirect', '/fr/')
-    params.set('email', email)
-    params.set('password', password)
+    const params = {
+      'redirect': '/fr/',
+      'email': email,
+      'password': password
+    }
     await this.client.post('https://piccoma.com/fr/api/auth/signin', params)
   }
 


### PR DESCRIPTION
Login with query parameters is no more accepted on the french version.